### PR TITLE
fix: added `email` as verification code source

### DIFF
--- a/SteamAuthentication/GuardLinking/GuardLinker.cs
+++ b/SteamAuthentication/GuardLinking/GuardLinker.cs
@@ -76,7 +76,7 @@ public class GuardLinker
         return (authSession, pollResponse, steamId);
     }
 
-    public async Task FinalizeAddGuardAsync(string smsCode, SteamMaFile maFile,
+    public async Task FinalizeAddGuardAsync(string verificationCode, SteamMaFile maFile,
         AuthPollResult pollResult,
         CancellationToken cancellationToken = default)
     {
@@ -90,7 +90,7 @@ public class GuardLinker
             { "steamid", maFile.Session!.SteamId.ToString() },
             { "authenticator_code", guardCode },
             { "authenticator_time", (await _steamTime.GetCurrentSteamTimeAsync(cancellationToken)).ToString() },
-            { "activation_code", smsCode },
+            { "activation_code", verificationCode },
             { "validate_sms_code", "1" },
         };
 
@@ -131,7 +131,7 @@ public class GuardLinker
                 finalizeContent, null);
 
         if (finalizeResponse.Response.Status == 89)
-            throw new RequestException("Wrong SMS code", response.StatusCode, response.Content, null);
+            throw new RequestException("Wrong verification code", response.StatusCode, response.Content, null);
 
         if (!finalizeResponse.Response.Success)
             throw new RequestException("Error while FinalizeAddAuthenticator", response.StatusCode, response.Content,

--- a/TradeOnSda/TradeOnSda/Views/AddGuardFirstStep/AddGuardView.axaml
+++ b/TradeOnSda/TradeOnSda/Views/AddGuardFirstStep/AddGuardView.axaml
@@ -85,10 +85,10 @@
                                 Orientation="Vertical">
                                 <TextBlock
                                     Classes="Text"
-                                    Text="Enter SMS code" />
+                                    Text="Enter the verification code (email/SMS)" />
                                 <TextBox
-                                    Watermark="SMS code"
-                                    Text="{Binding SmsCode}">
+                                    Watermark="Verification code"
+                                    Text="{Binding VerificationCode}">
                                 </TextBox>
                             </StackPanel>
                             <Grid

--- a/TradeOnSda/TradeOnSda/Views/AddGuardFirstStep/AddGuardViewModel.cs
+++ b/TradeOnSda/TradeOnSda/Views/AddGuardFirstStep/AddGuardViewModel.cs
@@ -140,7 +140,7 @@ public class AddGuardViewModel : ViewModelBase
     private GuardLinker? _guardLinker;
     private string _steamIdString;
     private string _accountName;
-    private string _smsCode;
+    private string _verificationCode;
 
     #endregion
 
@@ -152,10 +152,10 @@ public class AddGuardViewModel : ViewModelBase
         set => RaiseAndSetIfPropertyChanged(ref _isFinalizeStep, value);
     }
 
-    public string SmsCode
+    public string VerificationCode
     {
-        get => _smsCode;
-        set => RaiseAndSetIfPropertyChanged(ref _smsCode, value);
+        get => _verificationCode;
+        set => RaiseAndSetIfPropertyChanged(ref _verificationCode, value);
     }
 
     public ICommand FinalizeCommand { get; }
@@ -179,7 +179,7 @@ public class AddGuardViewModel : ViewModelBase
         _askStepTitle = "";
         _isEnabledLoginButton = true;
         _isFirstStep = true;
-        _smsCode = "";
+        _verificationCode = "";
         _lastPhoneNumber = "";
 
         TryLoginCommand = ReactiveCommand.CreateFromTask(async () =>
@@ -334,17 +334,17 @@ public class AddGuardViewModel : ViewModelBase
 
         FinalizeCommand = ReactiveCommand.CreateFromTask(async () =>
         {
-            if (string.IsNullOrWhiteSpace(SmsCode))
+            if (string.IsNullOrWhiteSpace(VerificationCode))
             {
                 await NotificationsMessageWindow.ShowWindow(
-                    $"Please, enter the SMS code",
+                    "Please, enter the verification code (email/SMS)",
                     ownerWindow);
                 return;
             }
 
             try
             {
-                await _guardLinker!.FinalizeAddGuardAsync(SmsCode, _maFile!, _pollResult!);
+                await _guardLinker!.FinalizeAddGuardAsync(VerificationCode, _maFile!, _pollResult!);
             }
             catch (RequestException e)
             {
@@ -387,7 +387,7 @@ public class AddGuardViewModel : ViewModelBase
         AddGuardCommand = null!;
         _steamIdString = null!;
         _accountName = null!;
-        _smsCode = null!;
+        _verificationCode = null!;
         _lastPhoneNumber = null!;
         FinalizeCommand = null!;
     }


### PR DESCRIPTION
Steam sends a verification code to your email if your phone number is not added to your account