### PR TITLE
feat: initial auto-confirm delay

### DIFF
--- a/TradeOnSda/TradeOnSda/Data/SdaWithCredentials.cs
+++ b/TradeOnSda/TradeOnSda/Data/SdaWithCredentials.cs
@@ -38,6 +38,9 @@ public class SdaWithCredentials
 
     private async Task AutoConfirmWorkingLoop()
     {
+        var autoConfirmDelayInSeconds = SdaSettings.AutoConfirmDelay.Seconds;
+        var initialDelay = Random.Shared.Next(minValue: 0, maxValue: autoConfirmDelayInSeconds + 1);
+        await Task.Delay(TimeSpan.FromSeconds(initialDelay));
         while (true)
         {
             await ProcessAutoConfirmAsync();


### PR DESCRIPTION
Added random initial auto-confirm delay to reduce HTTP 429 errors when using multiple accounts with a single proxy